### PR TITLE
UI rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+app/main.rb.bak

--- a/app/main.rb
+++ b/app/main.rb
@@ -66,8 +66,8 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	details = args.state.blueprints.structures[building]
 	
 	### Layout ###
-	dialog_border = args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(BORDER) 			# Main Dialog
-	dialog_ui_line = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(BORDER) 	# Dividing line
+	dialog_border = args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(BORDER)
+	dialog_ui_line = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(BORDER)
 	
 	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
@@ -77,14 +77,14 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 
 	
 	### Title ###
-	title_border = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(BORDER) # Title
+	title_border = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(BORDER)
 	title_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
 	title = {x: title_loc[:center_x], y: title_loc[:center_y] - 1, 
 							text: details[:name], size_enum: 2,
 							vertical_alignment_enum: 1, alignment_enum: 1}.merge(LABEL)
 	
 	### Description ###
-	description_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
+	description_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1)
 	description = textbox(details[:description],
 						description_loc[:x], description_loc[:center_y], 
 						description_loc[:w], 
@@ -93,19 +93,7 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	
 	### Cost ###
 	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args).merge(SPRITE)
-
-	
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25).merge(BORDER)
-	cost_hash = details[:cost]
-	costs_names = cost_hash.keys
-	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2, primitive_marker: :label}}
-	costs_values = cost_hash.values
-	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0, primitive_marker: :label}}
-
-	
-	cost_labels_names = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-	cost_labels_values = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
-
+	cost = vertical_paired_list({row: 10.1, col: 7.75, drow: 0.4}, details[:cost], -2, args)
 	
 	### Production / Consumption ###
 	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(SPRITE)
@@ -120,14 +108,13 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	consumption_text = horizontal_paired_list("Consumption: ", consumption_hash, DOWN, args)
 	consumption_label = {text: consumption_text, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(LABEL)
 
-	
+	### Renderables ###
 	dialog << args.state.buttons
 	dialog << title
 	dialog << title_border
 	dialog << description	
 	dialog << cost_ui
-	dialog << cost_labels_names
-	dialog << cost_labels_values
+	dialog << cost
 	dialog << prod_ui
 	dialog << consumption_label	
 	dialog << production_label
@@ -150,6 +137,22 @@ def horizontal_paired_list(label, hash, symbol=nil, args=$gtk.args)
 	label
 end
 
+def vertical_paired_list(layout, hash, size=0, args=$gtk.args)
+	left_array = hash.keys
+	right_array = hash.values
+	
+	left_array.map!{|name| {text: name.to_s.capitalize+":", size_enum: size, alignment_enum: 2, primitive_marker: :label}}
+	right_array.map!{|val| {text: val.to_s, size_enum: size, alignment_enum: 0, primitive_marker: :label}}
+
+	layout[:drow] ||= 0.4
+	
+	labels = []
+	labels << args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: left_array)
+	labels << args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: right_array)
+
+	labels
+end
+	
 def get_button_from_layout(layout, text, method, argument, target, args)
 	make_button(layout[:x], layout[:y], layout[:w], layout[:h], text, method, argument, target, args)
 end

--- a/app/main.rb
+++ b/app/main.rb
@@ -53,53 +53,58 @@ end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	raise unless building
+	dialog = args.state.renderables.dialog
 	details = args.state.blueprints.structures[building]
-	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) 			# Main Dialog
-	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) 	# Dividing line
+	border = {primitive_marker: :border}
+	sprite = {primitive_marker: :sprite}
+	line = {primitive_marker: :line}
+	label = {primitive_marker: :label}
+	args.outputs.primitives << args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
+	args.outputs.primitives << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
 	
 	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
 	build_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1), "Build", :build, building, :build_button, args)
 	
-	args.state.buttons = [build_button, back_button]
-	args.outputs.sprites << args.state.buttons
+	args.state.buttons = [build_button.merge(sprite), back_button.merge(sprite)]
+	args.outputs.primitives << args.state.buttons
 	
 	### Title ###
-	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
+	args.outputs.primitives << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(border) # Title
 	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
-	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							text: details[:name], size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+	args.outputs.primitives << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							text: details[:name], size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}.merge(label)
 	
 	### Description ###
 	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
 	text_box = textbox(details[:description],
-						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
-	args.outputs.labels << text_box	
+						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0, primitive_marker: :label})}
+	args.outputs.primitives	<< text_box	
 	
 	### Cost ###
 	#cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
 	#cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
-	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args)
-	args.outputs.sprites << cost_ui
+	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args).merge(sprite)
+	args.outputs.primitives << cost_ui
 	
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25).merge(border)
 	cost_hash = details[:cost]
 	costs_names = cost_hash.keys
-	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
+	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2, primitive_marker: :label}}
 	costs_values = cost_hash.values
-	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
+	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0, primitive_marker: :label}}
 
 	
 	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-	args.outputs.labels << cost_labels
+	args.outputs.primitives << cost_labels
 	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
-	args.outputs.labels << cost_labels2
+	args.outputs.primitives << cost_labels2
 	
 	### Production / Consumption ###
 	#prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
 	#prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
-	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args)
-	args.outputs.sprites << prod_ui
+	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(sprite)
+	args.outputs.primitives << prod_ui
 	
 	production_hash = details[:production]
 	production_label = "Production: "
@@ -120,12 +125,12 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	end
 	
 	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
-	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
-	args.outputs.labels << consumption_label
+	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
+	args.outputs.primitives << consumption_label
 	
 	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
-	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
-	args.outputs.labels << production_label
+	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
+	args.outputs.primitives << production_label
 	
 end
 

--- a/app/main.rb
+++ b/app/main.rb
@@ -48,44 +48,47 @@ def tick(args)
 	args.outputs.borders << args.layout.rect(row: 5, col: 19, w: 4, h: 2)
 	args.outputs.borders << args.layout.rect(row: 7, col: 19, w: 4, h: 2)
 	args.outputs.borders << args.layout.rect(row: 9, col: 19, w: 4, h: 2)
-		
+	
+	render(args)
 end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	raise unless building
+	args.state.renderables.dialog = []
 	dialog = args.state.renderables.dialog
 	details = args.state.blueprints.structures[building]
 	border = {primitive_marker: :border}
 	sprite = {primitive_marker: :sprite}
 	line = {primitive_marker: :line}
 	label = {primitive_marker: :label}
-	args.outputs.primitives << args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
-	args.outputs.primitives << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
+	dialog << args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
+	dialog << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
 	
 	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
 	build_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1), "Build", :build, building, :build_button, args)
 	
 	args.state.buttons = [build_button.merge(sprite), back_button.merge(sprite)]
-	args.outputs.primitives << args.state.buttons
+
 	
 	### Title ###
-	args.outputs.primitives << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(border) # Title
-	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
-	args.outputs.primitives << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							text: details[:name], size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}.merge(label)
+	title_border = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(border) # Title
+	title_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
+	title = {x: title_loc[:center_x], y: title_loc[:center_y] - 1, 
+							text: details[:name], size_enum: 2,
+							vertical_alignment_enum: 1, alignment_enum: 1}.merge(label)
 	
 	### Description ###
-	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
-	text_box = textbox(details[:description],
-						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0, primitive_marker: :label})}
-	args.outputs.primitives	<< text_box	
+	description_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
+	description = textbox(details[:description],
+						description_loc[:x], description_loc[:center_y], 
+						description_loc[:w], 
+						size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0, primitive_marker: :label})}
+
 	
 	### Cost ###
-	#cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
-	#cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
 	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args).merge(sprite)
-	args.outputs.primitives << cost_ui
+
 	
 	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25).merge(border)
 	cost_hash = details[:cost]
@@ -96,15 +99,13 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 
 	
 	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-	args.outputs.primitives << cost_labels
+
 	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
-	args.outputs.primitives << cost_labels2
+
 	
 	### Production / Consumption ###
-	#prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
-	#prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
 	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(sprite)
-	args.outputs.primitives << prod_ui
+
 	
 	production_hash = details[:production]
 	production_label = "Production: "
@@ -126,12 +127,26 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	
 	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
 	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
-	args.outputs.primitives << consumption_label
+
 	
 	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
 	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
-	args.outputs.primitives << production_label
 	
+	dialog << args.state.buttons
+	dialog << title
+	dialog << title_border
+	dialog << description	
+	dialog << cost_ui
+	dialog << cost_labels
+	dialog << cost_labels2
+	dialog << prod_ui
+	dialog << consumption_label	
+	dialog << production_label
+	
+end
+
+def render(args)
+	args.outputs.primitives << args.state.renderables.dialog
 end
 
 def get_button_from_layout(layout, text, method, argument, target, args)

--- a/app/main.rb
+++ b/app/main.rb
@@ -40,7 +40,6 @@ def tick(args)
 	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
 	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
 	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
-	#args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
 	args.outputs.borders << args.layout.rect(row: 0, col: 18, w: 6, h: 12) # Scene Control
 	
 	## Scene control buttons
@@ -49,81 +48,7 @@ def tick(args)
 	args.outputs.borders << args.layout.rect(row: 5, col: 19, w: 4, h: 2)
 	args.outputs.borders << args.layout.rect(row: 7, col: 19, w: 4, h: 2)
 	args.outputs.borders << args.layout.rect(row: 9, col: 19, w: 4, h: 2)
-	
-	## Main Dialog for Building Card
-	
-	#args.outputs.borders << args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
-	#args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
-	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
-	
-	# args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
-	# text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
-	# args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							# text: "Iron Ore Mine", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
-	
-	#text_loc = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back
-	#args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-	#						text: LEFT, size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
-
-	# text_loc = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
-	# args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							# text: "Build", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
-							
-	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1)
-	#text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
-	#text_box = textbox("Mining tunnels deep into rock, reinforced by wooden beams. Produces iron ore for refinement into iron.",
-	#					text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
-	#args.outputs.labels << text_box
-	
-	#args.outputs.borders << args.layout.rect(row: 10, col: 6.25, w: 3, h: 1.75) # costs
-	# cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
-	# cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
-	# args.outputs.sprites << cost_ui
-	
-	#args.outputs.borders << args.layout.rect(row: 10, col: 9.25, w: 8.5, h: 1.75) # production and consumption
-	# prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
-	# prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
-	# args.outputs.sprites << prod_ui
-	
-	# cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
-	# cost_hash = {wood: 30, workers: 3, tools: 3, charcoal: 1024}
-	# costs_names = cost_hash.keys
-	# costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
-	# costs_values = cost_hash.values
-	# costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
-
-	
-	# cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-	# args.outputs.labels << cost_labels
-	# cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
-	# args.outputs.labels << cost_labels2
-	
-	# production_hash = {iron_ore: 1}
-	# production_label = "Production: "
-	# add_comma = false
-	# production_hash.each do |res, val|
-		# production_label += "," if add_comma
-		# production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
-		# add_comma = true
-	# end	
-	
-	# consumption_hash = {food: 5, tools: 1, wood: 3}
-	# consumption_label = "Consumption: "
-	# add_comma = false
-	# consumption_hash.each do |res, val|
-		# consumption_label += "," if add_comma
-		# consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
-		# add_comma = true
-	# end
-	
-	# con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
-	# consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
-	# args.outputs.labels << consumption_label
-	
-	# prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
-	# production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
-	# args.outputs.labels << production_label
-	
+		
 end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
@@ -259,11 +184,6 @@ def init(args)
 	SIGNS = ["=", "▲", "▼"]
 	
 	prepare_ui(args)
-	
-	# UP = ▲
-	# DOWN = ▼
-	# RIGHT = ▶
-	# LEFT = ◀
 	
 	args.state.ready = true
 	$gtk.notify!("Init complete!")

--- a/app/main.rb
+++ b/app/main.rb
@@ -1,14 +1,108 @@
+# def tick(args)
+	# init(args) unless args.state.ready == true
+	# game_step(args)
+	# update_display(args)
+	# check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click
+# end
+
+	UP = "▲"
+	DOWN = "▼"
+	RIGHT = "▶"
+	LEFT = "◀"
+
 def tick(args)
-	init(args) unless args.state.ready == true
-	game_step(args)
-	update_display(args)
-	check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click
+	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
+	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
+	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
+	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
+	args.outputs.borders << args.layout.rect(row: 0, col: 18, w: 6, h: 12) # Scene Control
+	
+	## Scene control buttons
+	args.outputs.borders << args.layout.rect(row: 1, col: 19, w: 4, h: 2)
+	args.outputs.borders << args.layout.rect(row: 3, col: 19, w: 4, h: 2)
+	args.outputs.borders << args.layout.rect(row: 5, col: 19, w: 4, h: 2)
+	args.outputs.borders << args.layout.rect(row: 7, col: 19, w: 4, h: 2)
+	args.outputs.borders << args.layout.rect(row: 9, col: 19, w: 4, h: 2)
+	
+	## Main Dialog for Building Card
+	
+	args.outputs.borders << args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
+	args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
+	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
+	
+	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
+	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
+	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							text: "Iron Ore Mine", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+	
+	text_loc = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back
+	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							text: LEFT, size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+
+	text_loc = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
+	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							text: "Build", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+							
+	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1)
+	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
+	text_box = textbox("Mining tunnels deep into rock, reinforced by wooden beams. Produces iron ore for refinement into iron.",
+						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
+	args.outputs.labels << text_box
+	
+	#args.outputs.borders << args.layout.rect(row: 10, col: 6.25, w: 3, h: 1.75) # costs
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
+	cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
+	args.outputs.sprites << cost_ui
+	
+	#args.outputs.borders << args.layout.rect(row: 10, col: 9.25, w: 8.5, h: 1.75) # production and consumption
+	prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
+	prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
+	args.outputs.sprites << prod_ui
+	
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
+	cost_hash = {wood: 30, workers: 3, tools: 3, charcoal: 1024}
+	costs_names = cost_hash.keys
+	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
+	costs_values = cost_hash.values
+	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
+
+	
+	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
+	args.outputs.labels << cost_labels
+	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
+	args.outputs.labels << cost_labels2
+	
+	production_hash = {iron_ore: 1}
+	production_label = "Production: "
+	add_comma = false
+	production_hash.each do |res, val|
+		production_label += "," if add_comma
+		production_label += res.to_s.capitalize.gsub("_", " ") + " " + UP + val.to_s
+		add_comma = true
+	end	
+	
+	consumption_hash = {food: 5, tools: 1, wood: 3}
+	consumption_label = "Consumption: "
+	add_comma = false
+	consumption_hash.each do |res, val|
+		consumption_label += "," if add_comma
+		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + DOWN + val.to_s
+		add_comma = true
+	end
+	
+	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
+	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
+	args.outputs.labels << consumption_label
+	
+	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
+	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
+	args.outputs.labels << production_label
+	
 end
 
 def init(args)
 	args.state.production = Hash.new(0)
-	args.state.inventory = Hash.new(0)	
-	args.state.buildings = Hash.new(0)
+	args.state.inventory = Hash.new(0)
 	
 	args.state.blueprints.structures = {}
 	args.state.blueprints.structures[:iron_mine] =
@@ -56,6 +150,8 @@ def init(args)
 	
 	# UP = ▲
 	# DOWN = ▼
+	# RIGHT = ▶
+	# LEFT = ◀
 	
 	args.state.ready = true
 	$gtk.notify!("Init complete!")
@@ -207,9 +303,10 @@ end
 
 def textbox(string, x, y, w, size=0, font="default")    # <==<< # THIS METHOD TO BE USED
     text = string_to_lines(string, w, size, font)               # Accepts string and returns array of strings of desired length
+	return {x: x, y: y, text: text, size_enum: size, font: font} if text.is_a?(String)
     height_offset = get_height(string, size, font)              # Gets maximum height of any given line from the given string
     text.map!.with_index do |line, idx|                         # Converts array of string into array suitable for
-        [x, y - idx * height_offset, line, size, font]          # args.outputs.lables << textbox()
+        {x: x, y: y - idx * height_offset, text: line, size_enum: size, font: font}          # args.outputs.lables << textbox()
     end
 end
 
@@ -230,6 +327,7 @@ def string_to_lines(string, box_x, size, font)
         line.split                                              # Splits strings into arrays of words at any whitespace
                                                                 # Results in nested array, [[],[]]!
     end
+
     list_to_lines(list_of_strings, box_x, size, font)
 end
 

--- a/app/main.rb
+++ b/app/main.rb
@@ -149,8 +149,8 @@ def vertical_paired_list(layout, hash, size=0, args=$gtk.args)
 	layout[:drow] ||= 0.4
 	
 	labels = []
-	labels << args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: left_array)
-	labels << args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: right_array)
+	labels << args.layout.rect_group(layout.merge({group: left_array}))
+	labels << args.layout.rect_group(layout.merge({group: right_array}))
 
 	labels
 end

--- a/app/main.rb
+++ b/app/main.rb
@@ -9,6 +9,11 @@
 	DOWN = "▼"
 	RIGHT = "▶"
 	LEFT = "◀"
+	
+	BORDER = {primitive_marker: :border}
+	SPRITE = {primitive_marker: :sprite}
+	LINE = {primitive_marker: :line}
+	LABEL = {primitive_marker: :label}
 
 def tick(args)
 	args.state.production ||= Hash.new(0)
@@ -59,28 +64,24 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	args.state.renderables.dialog = []
 	dialog = args.state.renderables.dialog
 	details = args.state.blueprints.structures[building]
-	border = {primitive_marker: :border}
-	sprite = {primitive_marker: :sprite}
-	line = {primitive_marker: :line}
-	label = {primitive_marker: :label}
 	
 	### Layout ###
-	dialog_border = args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
-	dialog_ui_line = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
+	dialog_border = args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(BORDER) 			# Main Dialog
+	dialog_ui_line = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(BORDER) 	# Dividing line
 	
 	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
 	build_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1), "Build", :build, building, :build_button, args)
 	
-	args.state.buttons = [build_button.merge(sprite), back_button.merge(sprite)]
+	args.state.buttons = [build_button.merge(SPRITE), back_button.merge(SPRITE)]
 
 	
 	### Title ###
-	title_border = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(border) # Title
+	title_border = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1).merge(BORDER) # Title
 	title_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
 	title = {x: title_loc[:center_x], y: title_loc[:center_y] - 1, 
 							text: details[:name], size_enum: 2,
-							vertical_alignment_enum: 1, alignment_enum: 1}.merge(label)
+							vertical_alignment_enum: 1, alignment_enum: 1}.merge(LABEL)
 	
 	### Description ###
 	description_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
@@ -91,10 +92,10 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 
 	
 	### Cost ###
-	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args).merge(sprite)
+	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args).merge(SPRITE)
 
 	
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25).merge(border)
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25).merge(BORDER)
 	cost_hash = details[:cost]
 	costs_names = cost_hash.keys
 	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2, primitive_marker: :label}}
@@ -102,23 +103,22 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0, primitive_marker: :label}}
 
 	
-	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-
-	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
+	cost_labels_names = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
+	cost_labels_values = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
 
 	
 	### Production / Consumption ###
-	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(sprite)
+	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(SPRITE)
 
 	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
 	production_hash = details[:production]
 	production_text = horizontal_paired_list("Production: ", production_hash, UP, args)
-	production_label = {text: production_text, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
+	production_label = {text: production_text, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(LABEL)
 	
 	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
 	consumption_hash = details[:consumption]
 	consumption_text = horizontal_paired_list("Consumption: ", consumption_hash, DOWN, args)
-	consumption_label = {text: consumption_text, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
+	consumption_label = {text: consumption_text, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(LABEL)
 
 	
 	dialog << args.state.buttons
@@ -126,8 +126,8 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	dialog << title_border
 	dialog << description	
 	dialog << cost_ui
-	dialog << cost_labels
-	dialog << cost_labels2
+	dialog << cost_labels_names
+	dialog << cost_labels_values
 	dialog << prod_ui
 	dialog << consumption_label	
 	dialog << production_label

--- a/app/main.rb
+++ b/app/main.rb
@@ -57,14 +57,11 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) 			# Main Dialog
 	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) 	# Dividing line
 	
-	### Back Button ###
+	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
-	args.outputs.sprites << back_button
-	
-	### Build Button ###
 	build_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1), "Build", :build, building, :build_button, args)
 	
-	args.state.buttons = [build_button]
+	args.state.buttons = [build_button, back_button]
 	args.outputs.sprites << args.state.buttons
 	
 	### Title ###
@@ -80,8 +77,9 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	args.outputs.labels << text_box	
 	
 	### Cost ###
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
-	cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
+	#cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
+	#cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
+	cost_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25), :cost_box, "Cost", args)
 	args.outputs.sprites << cost_ui
 	
 	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
@@ -98,8 +96,9 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	args.outputs.labels << cost_labels2
 	
 	### Production / Consumption ###
-	prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
-	prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
+	#prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
+	#prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
+	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args)
 	args.outputs.sprites << prod_ui
 	
 	production_hash = details[:production]
@@ -133,6 +132,11 @@ end
 def get_button_from_layout(layout, text, method, argument, target, args)
 	make_button(layout[:x], layout[:y], layout[:w], layout[:h], text, method, argument, target, args)
 end
+
+def get_ui_box_from_layout(layout, target, text, args)
+	make_ui_box(target, text, layout[:w], layout[:h], args).merge({x: layout[:x], y: layout[:y]})
+end
+
 
 def select_building(to_select)
 	args.state.selection.building = to_select

--- a/app/main.rb
+++ b/app/main.rb
@@ -11,6 +11,9 @@
 	LEFT = "◀"
 
 def tick(args)
+	args.state.production ||= Hash.new(0)
+	args.state.inventory ||= Hash.new(0)
+
 	args.state.selection.building ||= :iron_mine
 	args.state.blueprints.structures = {}
 	args.state.blueprints.structures[:iron_mine] =
@@ -30,7 +33,10 @@ def tick(args)
 			description: "A tall chimney furnace able to smelt iron ore into somewhat usable metal"
 		}
 
-	dialog_box(:smelter, args)
+	dialog_box(args.state.selection.building, args)
+	
+	check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click
+	
 	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
 	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
 	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
@@ -135,7 +141,9 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	build_button_layout = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
 	bbl = build_button_layout
 	build_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], "Build", :build, building, :build_button, args)
-	args.outputs.sprites << build_button
+	
+	args.state.buttons = [build_button]
+	args.outputs.sprites << args.state.buttons
 	
 	### Title ###
 	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title

--- a/app/main.rb
+++ b/app/main.rb
@@ -54,6 +54,8 @@ end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	raise unless building
+	
+	### Overhead ###
 	args.state.renderables.dialog = []
 	dialog = args.state.renderables.dialog
 	details = args.state.blueprints.structures[building]
@@ -61,8 +63,10 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	sprite = {primitive_marker: :sprite}
 	line = {primitive_marker: :line}
 	label = {primitive_marker: :label}
-	dialog << args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
-	dialog << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
+	
+	### Layout ###
+	dialog_border = args.layout.rect(row: 7, col: 6, w: 12, h: 5).merge(border) 			# Main Dialog
+	dialog_ui_line = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0).merge(border) 	# Dividing line
 	
 	### Back and Build Buttons ###
 	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
@@ -127,7 +131,8 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	dialog << prod_ui
 	dialog << consumption_label	
 	dialog << production_label
-	
+	dialog << dialog_border
+	dialog << dialog_ui_line
 end
 
 def render(args)

--- a/app/main.rb
+++ b/app/main.rb
@@ -106,31 +106,18 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	### Production / Consumption ###
 	prod_ui = get_ui_box_from_layout(args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25), :prod_box, "Production and Consumption", args).merge(sprite)
 
-	
+	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
 	production_hash = details[:production]
-	production_label = "Production: "
-	add_comma = false
-	production_hash.each do |res, val|
-		production_label += "," if add_comma
-		production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
-		add_comma = true
-	end	
-	
-	consumption_hash = details[:consumption]
-	consumption_label = "Consumption: "
-	add_comma = false
-	consumption_hash.each do |res, val|
-		consumption_label += "," if add_comma
-		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
-		add_comma = true
-	end
+	production_header = "Production: "
+	production_text = horizontal_paired_list(production_header, production_hash, UP, args)
+	production_label = {text: production_text, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
 	
 	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
-	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
+	consumption_hash = details[:consumption]
+	consumption_header = "Consumption: "
+	consumption_text = horizontal_paired_list(consumption_header, consumption_hash, DOWN, args)
+	consumption_label = {text: consumption_text, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
 
-	
-	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
-	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
 	
 	dialog << args.state.buttons
 	dialog << title
@@ -147,6 +134,17 @@ end
 
 def render(args)
 	args.outputs.primitives << args.state.renderables.dialog
+end
+
+def horizontal_paired_list(label, hash, symbol=nil, args=$gtk.args)
+	add_comma = false
+	hash.each do |res, val|
+		label += "," if add_comma
+		label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s
+		label += symbol if symbol
+		add_comma = true
+	end
+	label
 end
 
 def get_button_from_layout(layout, text, method, argument, target, args)

--- a/app/main.rb
+++ b/app/main.rb
@@ -108,14 +108,12 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 
 	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
 	production_hash = details[:production]
-	production_header = "Production: "
-	production_text = horizontal_paired_list(production_header, production_hash, UP, args)
+	production_text = horizontal_paired_list("Production: ", production_hash, UP, args)
 	production_label = {text: production_text, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}.merge(label)
 	
 	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
 	consumption_hash = details[:consumption]
-	consumption_header = "Consumption: "
-	consumption_text = horizontal_paired_list(consumption_header, consumption_hash, DOWN, args)
+	consumption_text = horizontal_paired_list("Consumption: ", consumption_hash, DOWN, args)
 	consumption_label = {text: consumption_text, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}.merge(label)
 
 	

--- a/app/main.rb
+++ b/app/main.rb
@@ -21,7 +21,7 @@ def tick(args)
 			description: "Mining tunnels through deep into rock, producing iron ore"
 		}
 
-	dialog_box(args)
+	dialog_box(:iron_mine, args)
 	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
 	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
 	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
@@ -38,7 +38,7 @@ def tick(args)
 	## Main Dialog for Building Card
 	
 	#args.outputs.borders << args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
-	args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
+	#args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
 	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
 	
 	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
@@ -50,15 +50,15 @@ def tick(args)
 	#args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
 	#						text: LEFT, size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 
-	text_loc = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
-	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							text: "Build", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+	# text_loc = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
+	# args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							# text: "Build", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 							
 	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1)
-	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
-	text_box = textbox("Mining tunnels deep into rock, reinforced by wooden beams. Produces iron ore for refinement into iron.",
-						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
-	args.outputs.labels << text_box
+	#text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
+	#text_box = textbox("Mining tunnels deep into rock, reinforced by wooden beams. Produces iron ore for refinement into iron.",
+	#					text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
+	#args.outputs.labels << text_box
 	
 	#args.outputs.borders << args.layout.rect(row: 10, col: 6.25, w: 3, h: 1.75) # costs
 	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
@@ -88,7 +88,7 @@ def tick(args)
 	add_comma = false
 	production_hash.each do |res, val|
 		production_label += "," if add_comma
-		production_label += res.to_s.capitalize.gsub("_", " ") + " " + UP + val.to_s
+		production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
 		add_comma = true
 	end	
 	
@@ -97,7 +97,7 @@ def tick(args)
 	add_comma = false
 	consumption_hash.each do |res, val|
 		consumption_label += "," if add_comma
-		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + DOWN + val.to_s
+		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
 		add_comma = true
 	end
 	
@@ -112,12 +112,31 @@ def tick(args)
 end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
-	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
-	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
-	back_button_layout = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
+	details = args.state.blueprints.structures[building]
+	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) 			# Main Dialog
+	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) 	# Dividing line
+	
+	### Back Button ###
+	back_button_layout = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) 			# Back Button
 	bbl = back_button_layout
 	back_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], LEFT, :select_building, nil, :back_button, args)
 	args.outputs.sprites << back_button
+	
+	### Build Button ###
+	
+	build_button_layout = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
+	bbl = build_button_layout
+	build_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], "Build", :build, building, :build_button, args)
+	args.outputs.sprites << build_button
+
+	
+	
+	### Description ###
+	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
+	text_box = textbox(details[:description],
+						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
+	args.outputs.labels << text_box	
+	
 end
 
 def select_building(to_select)
@@ -327,7 +346,7 @@ end
 
 def textbox(string, x, y, w, size=0, font="default")    # <==<< # THIS METHOD TO BE USED
     text = string_to_lines(string, w, size, font)               # Accepts string and returns array of strings of desired length
-	return {x: x, y: y, text: text, size_enum: size, font: font} if text.is_a?(String)
+	return [{x: x, y: y, text: text, size_enum: size, font: font}] if text.is_a?(String)
     height_offset = get_height(string, size, font)              # Gets maximum height of any given line from the given string
     text.map!.with_index do |line, idx|                         # Converts array of string into array suitable for
         {x: x, y: y - idx * height_offset, text: line, size_enum: size, font: font}          # args.outputs.lables << textbox()

--- a/app/main.rb
+++ b/app/main.rb
@@ -14,6 +14,8 @@
 	SPRITE = {primitive_marker: :sprite}
 	LINE = {primitive_marker: :line}
 	LABEL = {primitive_marker: :label}
+	
+	FONT = "default"
 
 def tick(args)
 	args.state.production ||= Hash.new(0)
@@ -88,7 +90,7 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	description = textbox(details[:description],
 						description_loc[:x], description_loc[:center_y], 
 						description_loc[:w], 
-						size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0, primitive_marker: :label})}
+						size=-2, font=FONT).each{|t| t.merge!({vertical_alignment_enum: 0, primitive_marker: :label})}
 
 	
 	### Cost ###
@@ -254,8 +256,8 @@ def prepare_build_boxes(building, args) # key, args
 	box.sprites << make_ui_box(("build_" + building.to_s).to_sym, details[:name], 420, 130, args)
 	box.labels << textbox(details[:description], 10, 108, 390, size=-2, font="default")
 	box.lines << [10, 70, 410, 70]
-	box.sprites << make_ui_box(("cost_"+building.to_s).to_sym, ["Cost", -3, "default"], 150, 55, args).merge({x: 100, y: 10})
-	box.sprites << make_ui_box(("production_"+building.to_s), ["Production", -3, "default"], 150, 55, args).merge({x: 100 +150 +10 , y: 10})
+	box.sprites << make_ui_box(("cost_"+building.to_s).to_sym, ["Cost", -3, FONT], 150, 55, args).merge({x: 100, y: 10})
+	box.sprites << make_ui_box(("production_"+building.to_s), ["Production", -3, FONT], 150, 55, args).merge({x: 100 +150 +10 , y: 10})
 	positions = [[105, 17 + 5 + 12 + 12],[105, 17 + 12],[],[]]
 	position = 0
 	details[:cost].each do |resource, value|

--- a/app/main.rb
+++ b/app/main.rb
@@ -33,7 +33,7 @@ def tick(args)
 			description: "A tall chimney furnace able to smelt iron ore into somewhat usable metal"
 		}
 
-	dialog_box(args.state.selection.building, args)
+	dialog_box(args.state.selection.building, args)# if args.state.selection.building
 	
 	check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click
 	
@@ -52,20 +52,17 @@ def tick(args)
 end
 
 def dialog_box(building=args.state.selection.building, args=$gtk.args)
+	raise unless building
 	details = args.state.blueprints.structures[building]
 	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) 			# Main Dialog
 	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) 	# Dividing line
 	
 	### Back Button ###
-	back_button_layout = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) 			# Back Button
-	bbl = back_button_layout
-	back_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], LEFT, :select_building, nil, :back_button, args)
+	back_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1), LEFT, :select_building, nil, :back_button, args)
 	args.outputs.sprites << back_button
 	
 	### Build Button ###
-	build_button_layout = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
-	bbl = build_button_layout
-	build_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], "Build", :build, building, :build_button, args)
+	build_button = get_button_from_layout(args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1), "Build", :build, building, :build_button, args)
 	
 	args.state.buttons = [build_button]
 	args.outputs.sprites << args.state.buttons
@@ -131,6 +128,10 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
 	args.outputs.labels << production_label
 	
+end
+
+def get_button_from_layout(layout, text, method, argument, target, args)
+	make_button(layout[:x], layout[:y], layout[:w], layout[:h], text, method, argument, target, args)
 end
 
 def select_building(to_select)

--- a/app/main.rb
+++ b/app/main.rb
@@ -15,13 +15,22 @@ def tick(args)
 	args.state.blueprints.structures = {}
 	args.state.blueprints.structures[:iron_mine] =
 		{	name:		"Iron Ore Mine",
-			cost:		{wood: 20},
-			production:	{ore: 5},
+			cost:		{wood: 30, workers: 3},
+			production:	{ore: 1},
+			consumption: {wood: 3, tools: 1},
 			available: false,
-			description: "Mining tunnels through deep into rock, producing iron ore"
+			description: "Mining tunnels deep into rock, reinforced by wooden beams. Produces iron ore that requires refinement at a smelter."
+		}
+	args.state.blueprints.structures[:smelter] =
+		{	name:		"Smelter",
+			cost:		{stone: 60, wood: 20, workers: 2},
+			production:	{iron: 1},
+			consumption: {coal: 10, iron_ore: 10},
+			available: false,
+			description: "A tall chimney furnace able to smelt iron ore into somewhat usable metal"
 		}
 
-	dialog_box(:iron_mine, args)
+	dialog_box(:smelter, args)
 	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
 	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
 	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
@@ -41,10 +50,10 @@ def tick(args)
 	#args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
 	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
 	
-	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
-	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
-	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							text: "Iron Ore Mine", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+	# args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
+	# text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
+	# args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							# text: "Iron Ore Mine", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 	
 	#text_loc = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back
 	#args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
@@ -61,53 +70,53 @@ def tick(args)
 	#args.outputs.labels << text_box
 	
 	#args.outputs.borders << args.layout.rect(row: 10, col: 6.25, w: 3, h: 1.75) # costs
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
-	cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
-	args.outputs.sprites << cost_ui
+	# cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
+	# cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
+	# args.outputs.sprites << cost_ui
 	
 	#args.outputs.borders << args.layout.rect(row: 10, col: 9.25, w: 8.5, h: 1.75) # production and consumption
-	prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
-	prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
-	args.outputs.sprites << prod_ui
+	# prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
+	# prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
+	# args.outputs.sprites << prod_ui
 	
-	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
-	cost_hash = {wood: 30, workers: 3, tools: 3, charcoal: 1024}
-	costs_names = cost_hash.keys
-	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
-	costs_values = cost_hash.values
-	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
+	# cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
+	# cost_hash = {wood: 30, workers: 3, tools: 3, charcoal: 1024}
+	# costs_names = cost_hash.keys
+	# costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
+	# costs_values = cost_hash.values
+	# costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
 
 	
-	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
-	args.outputs.labels << cost_labels
-	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
-	args.outputs.labels << cost_labels2
+	# cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
+	# args.outputs.labels << cost_labels
+	# cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
+	# args.outputs.labels << cost_labels2
 	
-	production_hash = {iron_ore: 1}
-	production_label = "Production: "
-	add_comma = false
-	production_hash.each do |res, val|
-		production_label += "," if add_comma
-		production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
-		add_comma = true
-	end	
+	# production_hash = {iron_ore: 1}
+	# production_label = "Production: "
+	# add_comma = false
+	# production_hash.each do |res, val|
+		# production_label += "," if add_comma
+		# production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
+		# add_comma = true
+	# end	
 	
-	consumption_hash = {food: 5, tools: 1, wood: 3}
-	consumption_label = "Consumption: "
-	add_comma = false
-	consumption_hash.each do |res, val|
-		consumption_label += "," if add_comma
-		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
-		add_comma = true
-	end
+	# consumption_hash = {food: 5, tools: 1, wood: 3}
+	# consumption_label = "Consumption: "
+	# add_comma = false
+	# consumption_hash.each do |res, val|
+		# consumption_label += "," if add_comma
+		# consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
+		# add_comma = true
+	# end
 	
-	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
-	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
-	args.outputs.labels << consumption_label
+	# con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
+	# consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
+	# args.outputs.labels << consumption_label
 	
-	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
-	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
-	args.outputs.labels << production_label
+	# prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
+	# production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
+	# args.outputs.labels << production_label
 	
 end
 
@@ -123,19 +132,71 @@ def dialog_box(building=args.state.selection.building, args=$gtk.args)
 	args.outputs.sprites << back_button
 	
 	### Build Button ###
-	
 	build_button_layout = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
 	bbl = build_button_layout
 	build_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], "Build", :build, building, :build_button, args)
 	args.outputs.sprites << build_button
-
 	
+	### Title ###
+	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
+	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
+	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+							text: details[:name], size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 	
 	### Description ###
 	text_loc = args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 1) # Description
 	text_box = textbox(details[:description],
 						text_loc[:x], text_loc[:center_y], text_loc[:w], size=-2, font="default").each{|t| t.merge!({vertical_alignment_enum: 0})}
 	args.outputs.labels << text_box	
+	
+	### Cost ###
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25) # costs
+	cost_ui = make_ui_box(:cost_box, "Cost", cost_box[:w], cost_box[:h], args).merge({x: cost_box[:x], y: cost_box[:y]})
+	args.outputs.sprites << cost_ui
+	
+	cost_box = args.layout.rect(row: 9.5, col: 6.25, w: 3, h: 2.25)
+	cost_hash = details[:cost]
+	costs_names = cost_hash.keys
+	costs_names.map!{|name| {text: name.to_s.capitalize+":", size_enum: -2, alignment_enum: 2}}
+	costs_values = cost_hash.values
+	costs_values.map!{|val| {text: val.to_s, size_enum: -2, alignment_enum: 0}}
+
+	
+	cost_labels = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_names)
+	args.outputs.labels << cost_labels
+	cost_labels2 = args.layout.rect_group(row: 10.1, col: 7.75, drow: 0.4, group: costs_values)
+	args.outputs.labels << cost_labels2
+	
+	### Production / Consumption ###
+	prod_box = args.layout.rect(row: 9.5, col: 9.25, w: 8.5, h: 2.25) # production and consumption
+	prod_ui = make_ui_box(:prod_box, "Production and Consumption", prod_box[:w], prod_box[:h], args).merge({x: prod_box[:x], y: prod_box[:y]})
+	args.outputs.sprites << prod_ui
+	
+	production_hash = details[:production]
+	production_label = "Production: "
+	add_comma = false
+	production_hash.each do |res, val|
+		production_label += "," if add_comma
+		production_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + UP
+		add_comma = true
+	end	
+	
+	consumption_hash = details[:consumption]
+	consumption_label = "Consumption: "
+	add_comma = false
+	consumption_hash.each do |res, val|
+		consumption_label += "," if add_comma
+		consumption_label += res.to_s.capitalize.gsub("_", " ") + " " + val.to_s + DOWN
+		add_comma = true
+	end
+	
+	con_label_box = args.layout.rect(row: 9.2, col: 9.5, w: 8.5, h: 2.25)
+	consumption_label = {text: consumption_label, x: con_label_box[:x], y: con_label_box[:center_y], size_enum: -1}
+	args.outputs.labels << consumption_label
+	
+	prod_label_box = args.layout.rect(row: 9.8, col: 9.5, w: 8.5, h: 2.25)
+	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
+	args.outputs.labels << production_label
 	
 end
 
@@ -181,7 +242,7 @@ def init(args)
 			cost:		{wood: 100},
 			production:	{charcoal: 2},
 			available: true,
-			description: "Scaffolding across a rockface where usable stone is cut from the cliff"
+			description: "A pile of wood covered in earth and sealed so as to burn down into charcoal. An inefficient way to gain coal-type fuel."
 		}
 		
 	

--- a/app/main.rb
+++ b/app/main.rb
@@ -11,10 +11,21 @@
 	LEFT = "◀"
 
 def tick(args)
+	args.state.selection.building ||= :iron_mine
+	args.state.blueprints.structures = {}
+	args.state.blueprints.structures[:iron_mine] =
+		{	name:		"Iron Ore Mine",
+			cost:		{wood: 20},
+			production:	{ore: 5},
+			available: false,
+			description: "Mining tunnels through deep into rock, producing iron ore"
+		}
+
+	dialog_box(args)
 	args.outputs.borders << args.layout.rect(row: 0, col: 0, w: 6, h: 7) # M1
 	args.outputs.borders << args.layout.rect(row: 0, col: 6, w: 12, h: 7) # Viewport
 	args.outputs.borders << args.layout.rect(row: 7, col: 0, w: 6, h: 5) # M2
-	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
+	#args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
 	args.outputs.borders << args.layout.rect(row: 0, col: 18, w: 6, h: 12) # Scene Control
 	
 	## Scene control buttons
@@ -26,18 +37,18 @@ def tick(args)
 	
 	## Main Dialog for Building Card
 	
-	args.outputs.borders << args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
+	#args.outputs.borders << args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
 	args.outputs.borders << args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build Button
-	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
+	#args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
 	
 	args.outputs.borders << args.layout.rect(row: 7.25, col: 8, w: 7, h: 1) # Title
 	text_loc = args.layout.rect(row: 7.25, col: 8, w: 7, h: 1)
 	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
 							text: "Iron Ore Mine", size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 	
-	text_loc = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back
-	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
-							text: LEFT, size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
+	#text_loc = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back
+	#args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
+	#						text: LEFT, size_enum: 2, vertical_alignment_enum: 1, alignment_enum: 1}
 
 	text_loc = args.layout.rect(row: 7.25, col: 15.5, w: 2, h: 1) # Build
 	args.outputs.labels << {x: text_loc[:center_x], y: text_loc[:center_y] - 1, 
@@ -98,6 +109,19 @@ def tick(args)
 	production_label = {text: production_label, x: prod_label_box[:x], y: prod_label_box[:center_y], size_enum: -1}
 	args.outputs.labels << production_label
 	
+end
+
+def dialog_box(building=args.state.selection.building, args=$gtk.args)
+	args.outputs.borders << args.layout.rect(row: 7, col: 6, w: 12, h: 5) # Main Dialog
+	args.outputs.borders << args.layout.rect(row: 8.5, col: 6.25, w: 11.5, h: 0) # Dividing line
+	back_button_layout = args.layout.rect(row: 7.25, col: 6.5, w: 1, h: 1) # Back Button
+	bbl = back_button_layout
+	back_button ||= make_button(bbl[:x], bbl[:y], bbl[:w], bbl[:h], LEFT, :select_building, nil, :back_button, args)
+	args.outputs.sprites << back_button
+end
+
+def select_building(to_select)
+	args.state.selection.building = to_select
 end
 
 def init(args)

--- a/metadata/game_metadata.txt
+++ b/metadata/game_metadata.txt
@@ -1,8 +1,8 @@
-#devid=myname
+devid=m4rek
 #devtitle=My Name
 #gameid=mygame
-#gametitle=My Game
-#version=0.1
+gametitle=TeenyTinyCityBuilder
+version=0.0
 #icon=metadata/icon.png
 
 # Uncomment the entry below to bytecode compile your Ruby code (Pro License Only)


### PR DESCRIPTION
Full reworked existing UI, converting the building list into a general-case building card which will accept any standard building blueprint. Some methods standardised and existing UI elements converted to use them. Requires a way to select the active building - currently accessible only with select_building()