### PR TITLE
Implemented button_down functionality

### DIFF
--- a/app/main.rb
+++ b/app/main.rb
@@ -41,9 +41,8 @@ def tick(args)
 	prepare_resource_text(args)
 	box_M1(args)
 	box_M2(args)
-	
 	render(args)
-	check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click
+	check_mouse(args.inputs.mouse, args) if args.inputs.mouse.click || args.state.mouse_clicked
 	game_step(args)
 end
 
@@ -254,6 +253,8 @@ end
 
 def render(args)
 	args.outputs.primitives << args.state.buttons
+	#args.outputs.primitives << args.state.clicked_button
+	
 	args.outputs.primitives << args.state.renderables.dialog
 	args.outputs.primitives << args.state.renderables.m1
 end
@@ -467,17 +468,26 @@ def create_transaction(blueprint, args=$gtk.args)
 end
 
 def make_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
-	text_w, text_h = $gtk.calcstringbox(text)
-	args.render_target(target).height = h
-	args.render_target(target).width = w
-	out_x = x
-	out_y = y
-	x = 0
-	y = 0
-	args.render_target(target).borders << [x, y, w, h]
-	args.render_target(target).borders << [x, y+1, w-1, h-1]
-	args.render_target(target).borders << [x+2, y+2, w-4, h-4]
-	args.render_target(target).labels << [x + (w - text_w) / 2, y + (h + text_h) / 2 - 1, text]
+	clicked = (target.to_s+"_clicked").to_sym
+	unless args.state.rendered_buttons[target]
+		make_clicked_button(x, y, w, h, text, clicked, args)
+		text_w, text_h = $gtk.calcstringbox(text)
+		args.render_target(target).height = h
+		args.render_target(target).width = w
+		out_x = x
+		out_y = y
+		x = 0
+		y = 0
+		args.render_target(target).borders << [x, y, w, h]
+		args.render_target(target).borders << [x, y+1, w-1, h-1]
+		args.render_target(target).borders << [x+2, y+2, w-4, h-4]
+		args.render_target(target).labels << [x + (w - text_w) / 2, y + (h + text_h) / 2 - 1, text]
+	end
+	args.state.rendered_buttons ||= {}
+	args.state.rendered_buttons[target] = true
+	out_x ||= x
+	out_y ||= y
+	
 	{x: out_x, y: out_y, w: w, h: h, path: target, arguments: arguments, function: method(function)}
 end
 
@@ -491,15 +501,32 @@ def make_clicked_button(x, y, w, h, text, target, args=$gtk.args)
 	args.render_target(target).borders << [x+1, y, w-1, h-1]
 	args.render_target(target).borders << [x+2, y+2, w-4, h-4]
 	args.render_target(target).labels << [x + (w - text_w) / 2, y + (h + text_h) / 2 - 1, text]
-	{clicked_path: target}
+	#{clicked_path: target}
 end
 
 def check_mouse(mouse, args)
 	args.state.buttons.each do |button|
 		if mouse.inside_rect?(button)
-			button[:function].call(button[:arguments], args)
-			return # ends method, use break if further execution is desired
+			args.state.mouse_clicked = true
+			args.state.clicked_button = button
+			#button[:function].call(button[:arguments], args)
+			break # ends method, use break if further execution is desired
 		end
+	end unless args.state.mouse_clicked
+	on_button = false
+	if mouse.inside_rect?(args.state.clicked_button)
+		args.state.clicked_button[:path] = (args.state.clicked_button[:path].to_s+"_clicked").to_sym unless args.state.clicked_button_updated
+		args.state.clicked_button_updated = true
+		
+		puts args.state.clicked_button[:path]
+		args.outputs.sprites << args.state.clicked_button
+		on_button = true
+	end
+	if mouse.up
+		args.state.clicked_button[:function].call(args.state.clicked_button[:arguments], args) if on_button
+		args.state.mouse_clicked = false
+		args.state.clicked_button = nil
+		args.state.clicked_button_updated = nil
 	end
 end
 

--- a/app/main.rb
+++ b/app/main.rb
@@ -253,8 +253,6 @@ end
 
 def render(args)
 	args.outputs.primitives << args.state.buttons
-	#args.outputs.primitives << args.state.clicked_button
-	
 	args.outputs.primitives << args.state.renderables.dialog
 	args.outputs.primitives << args.state.renderables.m1
 end
@@ -501,7 +499,6 @@ def make_clicked_button(x, y, w, h, text, target, args=$gtk.args)
 	args.render_target(target).borders << [x+1, y, w-1, h-1]
 	args.render_target(target).borders << [x+2, y+2, w-4, h-4]
 	args.render_target(target).labels << [x + (w - text_w) / 2, y + (h + text_h) / 2 - 1, text]
-	#{clicked_path: target}
 end
 
 def check_mouse(mouse, args)
@@ -510,17 +507,11 @@ def check_mouse(mouse, args)
 			args.state.mouse_clicked = true
 			args.state.clicked_button = button
 			args.state.clicked_button_key = button[:path]
-			#button[:function].call(button[:arguments], args)
-			break # ends method, use break if further execution is desired
+			break
 		end
 	end unless args.state.mouse_clicked
 	on_button = false
 	if mouse.inside_rect?(args.state.clicked_button)
-		#args.state.clicked_button[:path] = (args.state.clicked_button[:path].to_s+"_clicked").to_sym unless args.state.clicked_button_updated
-		#args.state.clicked_button_updated = true
-		
-		#puts args.state.clicked_button[:path]
-		#args.outputs.sprites << args.state.clicked_button
 		args.state.clicked_button_key = args.state.clicked_button[:path]
 		on_button = true
 	end
@@ -529,7 +520,6 @@ def check_mouse(mouse, args)
 		args.state.clicked_button[:function].call(args.state.clicked_button[:arguments], args) if on_button
 		args.state.mouse_clicked = false
 		args.state.clicked_button = nil
-		#args.state.clicked_button_updated = nil
 		args.state.clicked_button_key = nil
 	end
 end

--- a/app/main.rb
+++ b/app/main.rb
@@ -468,7 +468,7 @@ end
 def make_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
 	clicked = (target.to_s+"_clicked").to_sym
 	unless args.state.rendered_buttons[target]
-		make_clicked_button(x, y, w, h, text, clicked, args)
+		make_clicked_button(w, h, text, clicked, args)
 		text_w, text_h = $gtk.calcstringbox(text)
 		args.render_target(target).height = h
 		args.render_target(target).width = w
@@ -489,7 +489,7 @@ def make_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
 	{x: out_x, y: out_y, w: w, h: h, path: target, arguments: arguments, function: method(function)}
 end
 
-def make_clicked_button(x, y, w, h, text, target, args=$gtk.args)
+def make_clicked_button(w, h, text, target, args=$gtk.args)
 	text_w, text_h = $gtk.calcstringbox(text)
 	args.render_target(target).height = h
 	args.render_target(target).width = w

--- a/app/main.rb
+++ b/app/main.rb
@@ -15,7 +15,6 @@ require 'app/textbox.rb'
 
 def tick(args)
 	load_structures(args) unless args.state.buildings.ready
-	#load_objectives(args) unless args.state.objectives.ready
 	
 	args.state.buttons = []
 	args.state.production ||= Hash.new(0)
@@ -61,7 +60,6 @@ def prepare_resource_text(args)
 			when 0..10000
 			else
 		end
-		#stock = stock.idiv(1000).to_s + "k" if stock > 10000
 		args.state.ui[resource] = "#{stock} (#{production})"
 	end
 end
@@ -483,19 +481,17 @@ def make_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
 	{x: out_x, y: out_y, w: w, h: h, path: target, arguments: arguments, function: method(function)}
 end
 
-def make_clicked_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
+def make_clicked_button(x, y, w, h, text, target, args=$gtk.args)
 	text_w, text_h = $gtk.calcstringbox(text)
 	args.render_target(target).height = h
 	args.render_target(target).width = w
-	out_x = x
-	out_y = y
 	x = 0
 	y = 0
 	args.render_target(target).borders << [x, y, w, h]
 	args.render_target(target).borders << [x+1, y, w-1, h-1]
 	args.render_target(target).borders << [x+2, y+2, w-4, h-4]
 	args.render_target(target).labels << [x + (w - text_w) / 2, y + (h + text_h) / 2 - 1, text]
-	{x: out_x, y: out_y, w: w, h: h, path: target, arguments: arguments, function: method(function)}
+	{clicked_path: target}
 end
 
 def check_mouse(mouse, args)

--- a/app/main.rb
+++ b/app/main.rb
@@ -487,7 +487,7 @@ def make_button(x, y, w, h, text, function, arguments, target, args=$gtk.args)
 	args.state.rendered_buttons[target] = true
 	out_x ||= x
 	out_y ||= y
-	
+	target = clicked if args.state.clicked_button_key == target
 	{x: out_x, y: out_y, w: w, h: h, path: target, arguments: arguments, function: method(function)}
 end
 
@@ -509,24 +509,28 @@ def check_mouse(mouse, args)
 		if mouse.inside_rect?(button)
 			args.state.mouse_clicked = true
 			args.state.clicked_button = button
+			args.state.clicked_button_key = button[:path]
 			#button[:function].call(button[:arguments], args)
 			break # ends method, use break if further execution is desired
 		end
 	end unless args.state.mouse_clicked
 	on_button = false
 	if mouse.inside_rect?(args.state.clicked_button)
-		args.state.clicked_button[:path] = (args.state.clicked_button[:path].to_s+"_clicked").to_sym unless args.state.clicked_button_updated
-		args.state.clicked_button_updated = true
+		#args.state.clicked_button[:path] = (args.state.clicked_button[:path].to_s+"_clicked").to_sym unless args.state.clicked_button_updated
+		#args.state.clicked_button_updated = true
 		
-		puts args.state.clicked_button[:path]
-		args.outputs.sprites << args.state.clicked_button
+		#puts args.state.clicked_button[:path]
+		#args.outputs.sprites << args.state.clicked_button
+		args.state.clicked_button_key = args.state.clicked_button[:path]
 		on_button = true
 	end
+	args.state.clicked_button_key = false unless on_button
 	if mouse.up
 		args.state.clicked_button[:function].call(args.state.clicked_button[:arguments], args) if on_button
 		args.state.mouse_clicked = false
 		args.state.clicked_button = nil
-		args.state.clicked_button_updated = nil
+		#args.state.clicked_button_updated = nil
+		args.state.clicked_button_key = nil
 	end
 end
 


### PR DESCRIPTION
Correctly shows the button_down sprite of the button when you click on it, but shows the normal sprite if you mouse off it with the button down; it ignores other UI buttons when you mouse over them with the mouse button down, and will only trigger the clicked button if you are on it when you release the mouse.